### PR TITLE
Allow use of external IR module by loading and applying IR main app's settings

### DIFF
--- a/xremote.c
+++ b/xremote.c
@@ -92,26 +92,28 @@ int32_t xremote_main(void* p) {
 
     bool otg_was_enabled = furi_hal_power_is_otg_enabled();
     InfraredSettings settings = {0};
-    saved_struct_load(
+    bool infrared_app_settings_loaded = saved_struct_load(
         INFRARED_SETTINGS_PATH,
         &settings,
         sizeof(InfraredSettings),
         INFRARED_SETTINGS_MAGIC,
         INFRARED_SETTINGS_VERSION);
-    if(settings.tx_pin < FuriHalInfraredTxPinMax) {
-        furi_hal_infrared_set_tx_output(settings.tx_pin);
-        if(settings.otg_enabled != otg_was_enabled) {
-            if(settings.otg_enabled) {
-                furi_hal_power_enable_otg();
-            } else {
-                furi_hal_power_disable_otg();
+    if(infrared_app_settings_loaded) {
+        if(settings.tx_pin < FuriHalInfraredTxPinMax) {
+            furi_hal_infrared_set_tx_output(settings.tx_pin);
+            if(settings.otg_enabled != otg_was_enabled) {
+                if(settings.otg_enabled) {
+                    furi_hal_power_enable_otg();
+                } else {
+                    furi_hal_power_disable_otg();
+                }
             }
-        }
-    } else {
-        FuriHalInfraredTxPin tx_pin_detected = furi_hal_infrared_detect_tx_output();
-        furi_hal_infrared_set_tx_output(tx_pin_detected);
-        if(tx_pin_detected != FuriHalInfraredTxPinInternal) {
-            furi_hal_power_enable_otg();
+        } else {
+            FuriHalInfraredTxPin tx_pin_detected = furi_hal_infrared_detect_tx_output();
+            furi_hal_infrared_set_tx_output(tx_pin_detected);
+            if(tx_pin_detected != FuriHalInfraredTxPinInternal) {
+                furi_hal_power_enable_otg();
+            }
         }
     }
 
@@ -119,12 +121,14 @@ int32_t xremote_main(void* p) {
     xremote_app_switch_to_view(app, XRemoteViewSubmenu);
     view_dispatcher_run(app->app_ctx->view_dispatcher);
 
-    furi_hal_infrared_set_tx_output(FuriHalInfraredTxPinInternal);
-    if(furi_hal_power_is_otg_enabled() != otg_was_enabled) {
-        if(otg_was_enabled) {
-            furi_hal_power_enable_otg();
-        } else {
-            furi_hal_power_disable_otg();
+    if(infrared_app_settings_loaded) {
+        furi_hal_infrared_set_tx_output(FuriHalInfraredTxPinInternal);
+        if(furi_hal_power_is_otg_enabled() != otg_was_enabled) {
+            if(otg_was_enabled) {
+                furi_hal_power_enable_otg();
+            } else {
+                furi_hal_power_disable_otg();
+            }
         }
     }
 

--- a/xremote.c
+++ b/xremote.c
@@ -13,8 +13,8 @@
 #include "xremote_analyzer.h"
 
 #include "views/xremote_about_view.h"
-#include "views/xremote_learn_view.h"
-#include "views/xremote_signal_view.h"
+
+#include <toolbox/saved_struct.h>
 
 #define TAG "XRemote"
 
@@ -90,9 +90,43 @@ int32_t xremote_main(void* p) {
     xremote_app_submenu_add(app, "Settings", XRemoteViewSettings, xremote_submenu_callback);
     xremote_app_submenu_add(app, "About", XRemoteViewAbout, xremote_submenu_callback);
 
+    bool otg_was_enabled = furi_hal_power_is_otg_enabled();
+    InfraredSettings settings = {0};
+    saved_struct_load(
+        INFRARED_SETTINGS_PATH,
+        &settings,
+        sizeof(InfraredSettings),
+        INFRARED_SETTINGS_MAGIC,
+        INFRARED_SETTINGS_VERSION);
+    if(settings.tx_pin < FuriHalInfraredTxPinMax) {
+        furi_hal_infrared_set_tx_output(settings.tx_pin);
+        if(settings.otg_enabled != otg_was_enabled) {
+            if(settings.otg_enabled) {
+                furi_hal_power_enable_otg();
+            } else {
+                furi_hal_power_disable_otg();
+            }
+        }
+    } else {
+        FuriHalInfraredTxPin tx_pin_detected = furi_hal_infrared_detect_tx_output();
+        furi_hal_infrared_set_tx_output(tx_pin_detected);
+        if(tx_pin_detected != FuriHalInfraredTxPinInternal) {
+            furi_hal_power_enable_otg();
+        }
+    }
+
     /* Switch to main menu by default and run disparcher*/
     xremote_app_switch_to_view(app, XRemoteViewSubmenu);
     view_dispatcher_run(app->app_ctx->view_dispatcher);
+
+    furi_hal_infrared_set_tx_output(FuriHalInfraredTxPinInternal);
+    if(furi_hal_power_is_otg_enabled() != otg_was_enabled) {
+        if(otg_was_enabled) {
+            furi_hal_power_enable_otg();
+        } else {
+            furi_hal_power_disable_otg();
+        }
+    }
 
     /* Cleanup and exit */
     xremote_app_free(app);

--- a/xremote.h
+++ b/xremote.h
@@ -8,9 +8,18 @@
 
 #include "xremote_app.h"
 
-#define XREMOTE_VERSION_MAJ 1
-#define XREMOTE_VERSION_MIN 3
+#define XREMOTE_VERSION_MAJ  1
+#define XREMOTE_VERSION_MIN  3
 #define XREMOTE_BUILD_NUMBER 0
 
 /* Returns FAP_VERSION + XREMOTE_BUILD_NUMBER */
 void xremote_get_version(char* version, size_t length);
+
+#define INFRARED_SETTINGS_PATH    EXT_PATH("infrared/.infrared.settings")
+#define INFRARED_SETTINGS_VERSION (1)
+#define INFRARED_SETTINGS_MAGIC   (0x1F)
+
+typedef struct {
+    FuriHalInfraredTxPin tx_pin;
+    bool otg_enabled;
+} InfraredSettings;


### PR DESCRIPTION
Hi!

While updating your app in [Unleashed apps repo](https://github.com/xMasterX/all-the-plugins) I notice that they implement support for external IR module based on IR main app's settings so I port this feature here.

Tested with IR Blaster, works like a charm!